### PR TITLE
Removed Company-Propfile from customer menu

### DIFF
--- a/src/SidebarMenu/SidebarMenu.js
+++ b/src/SidebarMenu/SidebarMenu.js
@@ -525,6 +525,8 @@ export default class SidebarMenu extends React.Component {
               </li>
             }
 
+            {
+            isSupplier &&
             <li
               className={`dropdown${
             this.state.currentOpenMenuName === 'Company' && ' open' || ''
@@ -592,6 +594,7 @@ export default class SidebarMenu extends React.Component {
                 </li>*/}
               </ul>
             </li>
+            }
 
             {/*<li className={`${this.state.activeMainMenuName === 'Settings' && ' active' || ''}`}>
               <a href="/bnp/settings" onClick={this.handleMenuItemClick.bind(this, '/bnp/settings', 'Settings')}>


### PR DESCRIPTION
Removed from Customer menu the item "Company" with the subitem "Profile" that links to SupplierInformation.